### PR TITLE
Extract wrap-around logic into WorldUtils helper

### DIFF
--- a/core/src/main/java/com/spamalot/arcade/robostar/Bomb.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/Bomb.java
@@ -27,17 +27,7 @@ public class Bomb {
       exploded = true;
     }
 
-    // wrap
-    if (pos.x < 0) {
-      pos.x += worldW;
-    } else if (pos.x >= worldW) {
-      pos.x -= worldW;
-    }
-    if (pos.y < 0) {
-      pos.y += worldH;
-    } else if (pos.y >= worldH) {
-      pos.y -= worldH;
-    }
+    WorldUtils.wrap(pos, worldW, worldH);
   }
 
   public void render(ShapeRenderer s) {

--- a/core/src/main/java/com/spamalot/arcade/robostar/Boss.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/Boss.java
@@ -23,17 +23,7 @@ public class Boss {
     vel.clamp(0, 120f);
     pos.mulAdd(vel, delta);
 
-    // wrap
-    if (pos.x < 0) {
-      pos.x += worldW;
-    } else if (pos.x >= worldW) {
-      pos.x -= worldW;
-    }
-    if (pos.y < 0) {
-      pos.y += worldH;
-    } else if (pos.y >= worldH) {
-      pos.y -= worldH;
-    }
+    WorldUtils.wrap(pos, worldW, worldH);
   }
 
   public void render(ShapeRenderer s) {

--- a/core/src/main/java/com/spamalot/arcade/robostar/Player.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/Player.java
@@ -31,7 +31,7 @@ public class Player {
     invuln = 2.0f;
   }
 
-  public void update(float delta, Vector2 moveInput, Vector2 wrapped, float worldW, float worldH) {
+  public void update(float delta, Vector2 moveInput, float worldW, float worldH) {
     // power timers
     if (speedBuff > 0) {
       speedBuff -= delta;
@@ -50,17 +50,7 @@ public class Player {
     vel.set(moveInput).nor().scl(spd);
     pos.add(vel.x * delta, vel.y * delta);
 
-    // wrap
-    if (pos.x < 0) {
-      pos.x += worldW;
-    } else if (pos.x >= worldW) {
-      pos.x -= worldW;
-    }
-    if (pos.y < 0) {
-      pos.y += worldH;
-    } else if (pos.y >= worldH) {
-      pos.y -= worldH;
-    }
+    WorldUtils.wrap(pos, worldW, worldH);
 
     if (shotTimer > 0) {
       shotTimer -= delta;

--- a/core/src/main/java/com/spamalot/arcade/robostar/WorldManager.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/WorldManager.java
@@ -70,7 +70,7 @@ class WorldManager {
     input.update();
 
     // Player movement & shooting
-    player.update(delta, input.getMove(), wrapPos(player.getPos()), GameRoot.WORLD_W, GameRoot.WORLD_H);
+    player.update(delta, input.getMove(), GameRoot.WORLD_W, GameRoot.WORLD_H);
     Vector2 aim = input.getAim();
     if (aim.len2() > 0.08f) {
       player.tryShoot(delta, aim, bullets);
@@ -155,7 +155,9 @@ class WorldManager {
 
     // camera follows player (wrap around)
     camera.position.set(player.getPos().x, player.getPos().y, 0);
-    wrapCamera();
+    Vector2 camPos = new Vector2(camera.position.x, camera.position.y);
+    WorldUtils.wrap(camPos, GameRoot.WORLD_W, GameRoot.WORLD_H);
+    camera.position.set(camPos.x, camPos.y, 0);
     camera.update();
   }
 
@@ -230,32 +232,4 @@ class WorldManager {
     }
   }
 
-  private void wrapCamera() {
-    if (camera.position.x < 0) {
-      camera.position.x += GameRoot.WORLD_W;
-    }
-    if (camera.position.x >= GameRoot.WORLD_W) {
-      camera.position.x -= GameRoot.WORLD_W;
-    }
-    if (camera.position.y < 0) {
-      camera.position.y += GameRoot.WORLD_H;
-    }
-    if (camera.position.y >= GameRoot.WORLD_H) {
-      camera.position.y -= GameRoot.WORLD_H;
-    }
-  }
-
-  Vector2 wrapPos(Vector2 p) {
-    if (p.x < 0) {
-      p.x += GameRoot.WORLD_W;
-    } else if (p.x >= GameRoot.WORLD_W) {
-      p.x -= GameRoot.WORLD_W;
-    }
-    if (p.y < 0) {
-      p.y += GameRoot.WORLD_H;
-    } else if (p.y >= GameRoot.WORLD_H) {
-      p.y -= GameRoot.WORLD_H;
-    }
-    return p;
-  }
 }

--- a/core/src/main/java/com/spamalot/arcade/robostar/WorldUtils.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/WorldUtils.java
@@ -1,0 +1,33 @@
+package com.spamalot.arcade.robostar;
+
+import com.badlogic.gdx.math.Vector2;
+
+/** Utility functions for world wrapping and related operations. */
+public final class WorldUtils {
+  private WorldUtils() {
+    // Utility class
+  }
+
+  /**
+   * Wrap a position around the world bounds so that objects exiting on one side
+   * re-enter on the opposite side.
+   *
+   * @param pos   position to wrap
+   * @param width world width
+   * @param height world height
+   * @return the wrapped position (same instance as provided)
+   */
+  public static Vector2 wrap(Vector2 pos, float width, float height) {
+    if (pos.x < 0) {
+      pos.x += width;
+    } else if (pos.x >= width) {
+      pos.x -= width;
+    }
+    if (pos.y < 0) {
+      pos.y += height;
+    } else if (pos.y >= height) {
+      pos.y -= height;
+    }
+    return pos;
+  }
+}


### PR DESCRIPTION
## Summary
- add `WorldUtils` with reusable `wrap` function
- replace duplicated wrap-around code in Player, Bomb, Boss, and WorldManager camera handling
- remove now-unneeded helper methods

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b2ea4c4083318297d37e6c6455ea