### PR TITLE
Introduce event dispatcher for boss build progress

### DIFF
--- a/core/src/main/java/com/spamalot/arcade/robostar/BossBuildProgressEvent.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/BossBuildProgressEvent.java
@@ -1,0 +1,8 @@
+package com.spamalot.arcade.robostar;
+
+/**
+ * Event published when the boss build progresses.
+ */
+public record BossBuildProgressEvent(float amount) implements GameEvent {
+}
+

--- a/core/src/main/java/com/spamalot/arcade/robostar/Enemy.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/Enemy.java
@@ -17,32 +17,34 @@ public class Enemy {
   private float radius = 10f;
   private boolean alive = true;
   private float carryCrystal = 0f; // for gatherers
+  private final EventDispatcher dispatcher;
 
-  public Enemy(Type type, Vector2 start) {
+  public Enemy(Type type, Vector2 start, EventDispatcher dispatcher) {
     this.type = type;
     this.pos.set(start);
+    this.dispatcher = dispatcher;
   }
 
-  public static Enemy hunter(Vector2 at) {
-    Enemy e = new Enemy(Type.HUNTER, at);
+  public static Enemy hunter(Vector2 at, EventDispatcher dispatcher) {
+    Enemy e = new Enemy(Type.HUNTER, at, dispatcher);
     e.radius = 10f;
     return e;
   }
 
-  public static Enemy gatherer(Vector2 at) {
-    Enemy e = new Enemy(Type.GATHERER, at);
+  public static Enemy gatherer(Vector2 at, EventDispatcher dispatcher) {
+    Enemy e = new Enemy(Type.GATHERER, at, dispatcher);
     e.radius = 9f;
     return e;
   }
 
-  public static Enemy converter(Vector2 at) {
-    Enemy e = new Enemy(Type.CONVERTER, at);
+  public static Enemy converter(Vector2 at, EventDispatcher dispatcher) {
+    Enemy e = new Enemy(Type.CONVERTER, at, dispatcher);
     e.radius = 11f;
     return e;
   }
 
-  public static Enemy zombie(Vector2 at) {
-    Enemy e = new Enemy(Type.ZOMBIE, at);
+  public static Enemy zombie(Vector2 at, EventDispatcher dispatcher) {
+    Enemy e = new Enemy(Type.ZOMBIE, at, dispatcher);
     e.radius = 9f;
     return e;
   }
@@ -130,12 +132,8 @@ public class Enemy {
     return best;
   }
 
-  // --- Hack: communicate progress to the active PlayScreen bossBuildProgress ---
   private void bossBuildProgressInc(float amt) {
-    // This is a placeholder hack, but we can't reference PlayScreen directly.
-    // In a more structured ECS, you'd use events. For the prototype,
-    // we'll simply update a global in GameBus. See GameBus class.
-    GameBus.bossBuildAdd += amt;
+    dispatcher.publish(new BossBuildProgressEvent(amt));
   }
 
   public void render(ShapeRenderer s) {

--- a/core/src/main/java/com/spamalot/arcade/robostar/EventDispatcher.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/EventDispatcher.java
@@ -1,0 +1,15 @@
+package com.spamalot.arcade.robostar;
+
+import java.util.function.Consumer;
+
+/**
+ * Simple event dispatcher interface using the observer pattern.
+ */
+public interface EventDispatcher {
+  /** Register a listener for a specific event type. */
+  <T extends GameEvent> void subscribe(Class<T> eventType, Consumer<T> listener);
+
+  /** Publish an event to all subscribed listeners. */
+  void publish(GameEvent event);
+}
+

--- a/core/src/main/java/com/spamalot/arcade/robostar/GameBus.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/GameBus.java
@@ -1,9 +1,0 @@
-package com.spamalot.arcade.robostar;
-
-/**
- * Extremely tiny "event bus" for the prototype to communicate simple scalars
- * across entities without heavy coupling. Reset per-frame by PlayScreen.
- */
-public class GameBus {
-  public static float bossBuildAdd = 0f;
-}

--- a/core/src/main/java/com/spamalot/arcade/robostar/GameEvent.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/GameEvent.java
@@ -1,0 +1,8 @@
+package com.spamalot.arcade.robostar;
+
+/**
+ * Marker interface for game events.
+ */
+public interface GameEvent {
+}
+

--- a/core/src/main/java/com/spamalot/arcade/robostar/PlayScreen.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/PlayScreen.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.GL20;
 
+
 /**
  * Main play screen delegating world updates and rendering.
  */
@@ -11,11 +12,14 @@ public class PlayScreen implements Screen {
   private final GameRoot game;
   private final WorldManager world;
   private final HudRenderer hud;
+  private final EventDispatcher dispatcher;
 
   public PlayScreen(GameRoot game) {
     this.game = game;
-    this.world = new WorldManager(game);
+    this.dispatcher = new SimpleEventDispatcher();
+    this.world = new WorldManager(game, dispatcher);
     this.hud = new HudRenderer(game, world);
+    dispatcher.subscribe(BossBuildProgressEvent.class, e -> world.addBossBuildProgress(e.amount()));
   }
 
   @Override

--- a/core/src/main/java/com/spamalot/arcade/robostar/SimpleEventDispatcher.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/SimpleEventDispatcher.java
@@ -1,0 +1,33 @@
+package com.spamalot.arcade.robostar;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Basic in-memory implementation of the {@link EventDispatcher}.
+ */
+public class SimpleEventDispatcher implements EventDispatcher {
+  private final Map<Class<?>, List<Consumer<?>>> listeners = new HashMap<>();
+
+  @Override
+  public synchronized <T extends GameEvent> void subscribe(Class<T> eventType, Consumer<T> listener) {
+    listeners.computeIfAbsent(eventType, k -> new ArrayList<>()).add(listener);
+  }
+
+  @Override
+  public synchronized void publish(GameEvent event) {
+    List<Consumer<?>> eventListeners = listeners.get(event.getClass());
+    if (eventListeners == null) {
+      return;
+    }
+    for (Consumer<?> raw : eventListeners) {
+      @SuppressWarnings("unchecked")
+      Consumer<GameEvent> listener = (Consumer<GameEvent>) raw;
+      listener.accept(event);
+    }
+  }
+}
+

--- a/core/src/main/java/com/spamalot/arcade/robostar/WorldManager.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/WorldManager.java
@@ -44,9 +44,11 @@ class WorldManager {
   float bossBuildProgress = 0f; // increased by Gatherers "delivering"
 
   private final CollisionHandler collisionHandler;
+  private final EventDispatcher dispatcher;
 
-  WorldManager(GameRoot game) {
+  WorldManager(GameRoot game, EventDispatcher dispatcher) {
     this.game = game;
+    this.dispatcher = dispatcher;
     this.camera = new OrthographicCamera(GameRoot.VIEW_W, GameRoot.VIEW_H);
     this.viewport = new FitViewport(GameRoot.VIEW_W, GameRoot.VIEW_H, camera);
     camera.position.set(GameRoot.VIEW_W / 2f, GameRoot.VIEW_H / 2f, 0);
@@ -63,9 +65,6 @@ class WorldManager {
     time += delta;
     spawnTimer += delta;
     waveTimer += delta;
-
-    bossBuildProgress = Math.min(1f, bossBuildProgress + GameBus.bossBuildAdd);
-    GameBus.bossBuildAdd = 0f;
 
     input.update();
 
@@ -129,11 +128,11 @@ class WorldManager {
       spawnTimer = 0f;
       int type = MathUtils.random(2);
       if (type == 0) {
-        enemies.add(Enemy.hunter(randWorld()));
+        enemies.add(Enemy.hunter(randWorld(), dispatcher));
       } else if (type == 1) {
-        enemies.add(Enemy.gatherer(randWorld()));
+        enemies.add(Enemy.gatherer(randWorld(), dispatcher));
       } else {
-        enemies.add(Enemy.converter(randWorld()));
+        enemies.add(Enemy.converter(randWorld(), dispatcher));
       }
       if (MathUtils.randomBoolean(0.6f)) {
         crystals.add(Pickup.crystal(randWorld()));
@@ -202,13 +201,13 @@ class WorldManager {
       humans.add(Pickup.human(randWorld()));
     }
     for (int i = 0; i < 15; i++) {
-      enemies.add(Enemy.hunter(randWorld()));
+      enemies.add(Enemy.hunter(randWorld(), dispatcher));
     }
     for (int i = 0; i < 10; i++) {
-      enemies.add(Enemy.gatherer(randWorld()));
+      enemies.add(Enemy.gatherer(randWorld(), dispatcher));
     }
     for (int i = 0; i < 6; i++) {
-      enemies.add(Enemy.converter(randWorld()));
+      enemies.add(Enemy.converter(randWorld(), dispatcher));
     }
   }
 
@@ -222,14 +221,18 @@ class WorldManager {
     boss = null;
     bossBuildProgress = 0f;
     for (int i = 0; i < 10 + wave * 3; i++) {
-      enemies.add(Enemy.hunter(randWorld()));
+      enemies.add(Enemy.hunter(randWorld(), dispatcher));
     }
     for (int i = 0; i < 6 + wave * 2; i++) {
-      enemies.add(Enemy.gatherer(randWorld()));
+      enemies.add(Enemy.gatherer(randWorld(), dispatcher));
     }
     for (int i = 0; i < 4 + wave; i++) {
-      enemies.add(Enemy.converter(randWorld()));
+      enemies.add(Enemy.converter(randWorld(), dispatcher));
     }
+  }
+
+  void addBossBuildProgress(float amt) {
+    bossBuildProgress = Math.min(1f, bossBuildProgress + amt);
   }
 
 }


### PR DESCRIPTION
## Summary
- Replace GameBus with a simple event dispatcher interface
- Emit `BossBuildProgressEvent` from enemies instead of mutating globals
- Subscribe in `PlayScreen` to update boss build progress

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b68244e88331925bf4707bc9d0d5