### PR TITLE
Add asset repository for textures

### DIFF
--- a/core/src/main/java/com/spamalot/arcade/robostar/Direction.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/Direction.java
@@ -1,0 +1,11 @@
+package com.spamalot.arcade.robostar;
+
+/**
+ * Cardinal directions used for sprite lookup.
+ */
+public enum Direction {
+  UP,
+  DOWN,
+  LEFT,
+  RIGHT;
+}

--- a/core/src/main/java/com/spamalot/arcade/robostar/GameRoot.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/GameRoot.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 
 import com.spamalot.arcade.robostar.input.InputController;
 import com.spamalot.arcade.robostar.screen.MenuScreen;
+import com.spamalot.arcade.robostar.asset.AssetRepository;
 
 public class GameRoot extends Game {
   public SpriteBatch batch;
@@ -16,6 +17,7 @@ public class GameRoot extends Game {
   public BitmapFont font;
   public Preferences prefs;
   public InputController input;
+  public AssetRepository assets;
 
   public static final int VIEW_W = 1280;
   public static final int VIEW_H = 720;
@@ -29,6 +31,8 @@ public class GameRoot extends Game {
     font = new BitmapFont(); // default font
     prefs = Gdx.app.getPreferences("hybrid-arcade-shooter");
     input = new InputController();
+    assets = new AssetRepository();
+    assets.load();
     setScreen(new MenuScreen(this));
   }
 
@@ -39,6 +43,9 @@ public class GameRoot extends Game {
     shapes.dispose();
     font.dispose();
     input.dispose();
+    if (assets != null) {
+      assets.dispose();
+    }
   }
 
   public int getHighScore() {

--- a/core/src/main/java/com/spamalot/arcade/robostar/asset/AssetRepository.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/asset/AssetRepository.java
@@ -1,0 +1,76 @@
+package com.spamalot.arcade.robostar.asset;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.Array;
+import com.spamalot.arcade.robostar.Direction;
+
+/**
+ * Loads and stores image assets for game entities.
+ *
+ * <p>The repository loads sprite sheets for each {@link Direction}. Each
+ * sheet is assumed to contain square frames laid out horizontally.</p>
+ */
+public class AssetRepository {
+  private final Map<Direction, TextureRegion[]> playerFrames = new EnumMap<>(Direction.class);
+  private final Map<Direction, TextureRegion[]> enemyFrames = new EnumMap<>(Direction.class);
+
+  /** All textures that need disposing. */
+  private final Array<Texture> managedTextures = new Array<>();
+
+  /** Load all assets. */
+  public void load() {
+    loadDirectional("player/player", playerFrames);
+    loadDirectional("enemy/enemy", enemyFrames);
+  }
+
+  private void loadDirectional(String prefix, Map<Direction, TextureRegion[]> out) {
+    for (Direction dir : Direction.values()) {
+      String path = prefix + "_" + dir.name().toLowerCase() + ".png";
+      FileHandle handle = Gdx.files.internal(path);
+      if (!handle.exists()) {
+        continue; // allow missing assets during development
+      }
+      Texture tex = new Texture(handle);
+      managedTextures.add(tex);
+      int frameSize = tex.getHeight();
+      int count = Math.max(1, tex.getWidth() / frameSize);
+      TextureRegion[] frames = new TextureRegion[count];
+      for (int i = 0; i < count; i++) {
+        frames[i] = new TextureRegion(tex, i * frameSize, 0, frameSize, frameSize);
+      }
+      out.put(dir, frames);
+    }
+  }
+
+  private TextureRegion getFrame(Map<Direction, TextureRegion[]> map, Direction dir, int frame) {
+    TextureRegion[] arr = map.get(dir);
+    if (arr == null || arr.length == 0) {
+      return null;
+    }
+    return arr[frame % arr.length];
+  }
+
+  /** Retrieve a player animation frame. */
+  public TextureRegion getPlayerFrame(Direction dir, int frame) {
+    return getFrame(playerFrames, dir, frame);
+  }
+
+  /** Retrieve an enemy animation frame. */
+  public TextureRegion getEnemyFrame(Direction dir, int frame) {
+    return getFrame(enemyFrames, dir, frame);
+  }
+
+  /** Dispose of all loaded textures. */
+  public void dispose() {
+    for (Texture t : managedTextures) {
+      t.dispose();
+    }
+    managedTextures.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce AssetRepository to load and manage sprite sheets for entities
- wire AssetRepository into GameRoot lifecycle
- add simple Direction enum used for directional frame lookup

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b8f4696b888331be88c567a9910f53