### PR TITLE
Replace ShapeRenderer entity rendering with SpriteBatch

### DIFF
--- a/core/src/main/java/com/spamalot/arcade/robostar/asset/AssetRepository.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/asset/AssetRepository.java
@@ -20,18 +20,33 @@ public class AssetRepository {
   private final Map<Direction, TextureRegion[]> playerFrames = new EnumMap<>(Direction.class);
   private final Map<Direction, TextureRegion[]> enemyFrames = new EnumMap<>(Direction.class);
 
+  /** Additional entity textures. */
+  private Texture bulletTex;
+  private Texture bombTex;
+  private Texture crystalTex;
+  private Texture humanTex;
+  private Texture explosionTex;
+  private Texture bossTex;
+
   /** All textures that need disposing. */
   private final Array<Texture> managedTextures = new Array<>();
 
   /** Load all assets. */
   public void load() {
-    loadDirectional("player/player", playerFrames);
-    loadDirectional("enemy/enemy", enemyFrames);
+    loadDirectional("sprites/player", playerFrames);
+    loadDirectional("sprites/enemy", enemyFrames);
+
+    bulletTex = loadTexture("sprites/bullet/bullet.png");
+    bombTex = loadTexture("sprites/bomb/bomb.png");
+    crystalTex = loadTexture("sprites/pickup/crystal/crystal.png");
+    humanTex = loadTexture("sprites/pickup/human/human.png");
+    explosionTex = loadTexture("sprites/explosion/1.png");
+    bossTex = loadTexture("sprites/boss/down.png");
   }
 
   private void loadDirectional(String prefix, Map<Direction, TextureRegion[]> out) {
     for (Direction dir : Direction.values()) {
-      String path = prefix + "_" + dir.name().toLowerCase() + ".png";
+      String path = prefix + "/" + dir.name().toLowerCase() + ".png";
       FileHandle handle = Gdx.files.internal(path);
       if (!handle.exists()) {
         continue; // allow missing assets during development
@@ -46,6 +61,16 @@ public class AssetRepository {
       }
       out.put(dir, frames);
     }
+  }
+
+  private Texture loadTexture(String path) {
+    FileHandle handle = Gdx.files.internal(path);
+    if (!handle.exists()) {
+      return null;
+    }
+    Texture tex = new Texture(handle);
+    managedTextures.add(tex);
+    return tex;
   }
 
   private TextureRegion getFrame(Map<Direction, TextureRegion[]> map, Direction dir, int frame) {
@@ -64,6 +89,30 @@ public class AssetRepository {
   /** Retrieve an enemy animation frame. */
   public TextureRegion getEnemyFrame(Direction dir, int frame) {
     return getFrame(enemyFrames, dir, frame);
+  }
+
+  public Texture getBullet() {
+    return bulletTex;
+  }
+
+  public Texture getBomb() {
+    return bombTex;
+  }
+
+  public Texture getCrystal() {
+    return crystalTex;
+  }
+
+  public Texture getHuman() {
+    return humanTex;
+  }
+
+  public Texture getExplosion() {
+    return explosionTex;
+  }
+
+  public Texture getBoss() {
+    return bossTex;
   }
 
   /** Dispose of all loaded textures. */

--- a/core/src/main/java/com/spamalot/arcade/robostar/entity/Bomb.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/entity/Bomb.java
@@ -1,7 +1,7 @@
 package com.spamalot.arcade.robostar.entity;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
 
 import com.spamalot.arcade.robostar.world.WorldUtils;
@@ -32,11 +32,12 @@ public class Bomb {
     WorldUtils.wrap(pos, worldW, worldH);
   }
 
-  public void render(ShapeRenderer s) {
-    if (!exploded) {
-      s.setColor(Color.RED);
-      s.circle(pos.x, pos.y, radius);
+  public void render(SpriteBatch batch, Texture tex) {
+    if (exploded || tex == null) {
+      return;
     }
+    float size = radius * 2f;
+    batch.draw(tex, pos.x - radius, pos.y - radius, size, size);
   }
 
   public Vector2 getPos() {

--- a/core/src/main/java/com/spamalot/arcade/robostar/entity/Boss.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/entity/Boss.java
@@ -1,8 +1,7 @@
 package com.spamalot.arcade.robostar.entity;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
-import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
 
 import com.spamalot.arcade.robostar.world.WorldUtils;
@@ -28,16 +27,12 @@ public class Boss {
     WorldUtils.wrap(pos, worldW, worldH);
   }
 
-  public void render(ShapeRenderer s) {
-    s.setColor(Color.SCARLET);
-    s.circle(pos.x, pos.y, radius, 24);
-    // "eye"
-    s.setColor(Color.BLACK);
-    s.circle(pos.x + MathUtils.cosDeg((System.currentTimeMillis() / 10) % 360) * 10f, pos.y, 8f);
-    // health ring
-    s.setColor(Color.PINK);
-    float ring = Math.max(0, hp) / 220f;
-    s.circle(pos.x, pos.y, radius + 4f * ring, 24);
+  public void render(SpriteBatch batch, Texture tex) {
+    if (tex == null) {
+      return;
+    }
+    float size = radius * 2f;
+    batch.draw(tex, pos.x - radius, pos.y - radius, size, size);
   }
 
   public Vector2 getPos() {

--- a/core/src/main/java/com/spamalot/arcade/robostar/entity/Bullet.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/entity/Bullet.java
@@ -1,7 +1,7 @@
 package com.spamalot.arcade.robostar.entity;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
 
 public class Bullet {
@@ -35,9 +35,12 @@ public class Bullet {
     }
   }
 
-  public void render(ShapeRenderer s) {
-    s.setColor(Color.YELLOW);
-    s.circle(pos.x, pos.y, radius);
+  public void render(SpriteBatch batch, Texture tex) {
+    if (tex == null) {
+      return;
+    }
+    float size = radius * 2f;
+    batch.draw(tex, pos.x - radius, pos.y - radius, size, size);
   }
 
   public Vector2 getPos() {

--- a/core/src/main/java/com/spamalot/arcade/robostar/entity/Enemy.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/entity/Enemy.java
@@ -1,13 +1,15 @@
 package com.spamalot.arcade.robostar.entity;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 
 import com.spamalot.arcade.robostar.event.BossBuildProgressEvent;
 import com.spamalot.arcade.robostar.event.EventDispatcher;
+import com.spamalot.arcade.robostar.asset.AssetRepository;
+import com.spamalot.arcade.robostar.Direction;
 
 public class Enemy {
   public enum Type {
@@ -139,26 +141,20 @@ public class Enemy {
     dispatcher.publish(new BossBuildProgressEvent(amt));
   }
 
-  public void render(ShapeRenderer s) {
-    switch (type) {
-      case HUNTER:
-        s.setColor(Color.FIREBRICK);
-        break;
-      case GATHERER:
-        s.setColor(Color.CORAL);
-        break;
-      case CONVERTER:
-        s.setColor(Color.PURPLE);
-        break;
-      case ZOMBIE:
-        s.setColor(Color.GREEN);
-        break;
+  public void render(SpriteBatch batch, AssetRepository assets) {
+    TextureRegion frame = assets.getEnemyFrame(direction(), 0);
+    if (frame == null) {
+      return;
     }
-    s.circle(pos.x, pos.y, radius);
-    if (carryCrystal > 0) {
-      s.setColor(Color.CYAN);
-      s.circle(pos.x, pos.y + radius + 2, 2f);
+    float size = radius * 2f;
+    batch.draw(frame, pos.x - radius, pos.y - radius, size, size);
+  }
+
+  private Direction direction() {
+    if (Math.abs(vel.x) > Math.abs(vel.y)) {
+      return vel.x >= 0 ? Direction.RIGHT : Direction.LEFT;
     }
+    return vel.y >= 0 ? Direction.UP : Direction.DOWN;
   }
 
   public Vector2 getPos() {

--- a/core/src/main/java/com/spamalot/arcade/robostar/entity/Explosion.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/entity/Explosion.java
@@ -1,7 +1,8 @@
 package com.spamalot.arcade.robostar.entity;
 
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
 
 public class Explosion {
@@ -22,10 +23,14 @@ public class Explosion {
     }
   }
 
-  public void render(ShapeRenderer s) {
+  public void render(SpriteBatch batch, Texture tex) {
+    if (tex == null) {
+      return;
+    }
     float t = Math.min(1f, time / dur);
     float r = 30 + 120 * t;
-    s.setColor(new Color(1f, 0.5f * (1f - t), 0, 0.6f * (1f - t) + 0.2f));
-    s.circle(pos.x, pos.y, r, 24);
+    batch.setColor(new Color(1f, 0.5f * (1f - t), 0, 0.6f * (1f - t) + 0.2f));
+    batch.draw(tex, pos.x - r, pos.y - r, r * 2f, r * 2f);
+    batch.setColor(Color.WHITE);
   }
 }

--- a/core/src/main/java/com/spamalot/arcade/robostar/entity/Pickup.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/entity/Pickup.java
@@ -1,8 +1,10 @@
 package com.spamalot.arcade.robostar.entity;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
+
+import com.spamalot.arcade.robostar.asset.AssetRepository;
 
 public class Pickup {
   public enum Kind {
@@ -30,21 +32,13 @@ public class Pickup {
     return p;
   }
 
-  public void render(ShapeRenderer s) {
-    switch (kind) {
-      case CRYSTAL:
-        s.setColor(Color.CYAN);
-        // diamond shape
-        s.triangle(pos.x, pos.y + radius, pos.x - radius, pos.y, pos.x + radius, pos.y);
-        s.triangle(pos.x, pos.y - radius, pos.x - radius, pos.y, pos.x + radius, pos.y);
-        break;
-      case HUMAN:
-        s.setColor(Color.SKY);
-        s.circle(pos.x, pos.y, radius);
-        s.setColor(Color.WHITE);
-        s.rect(pos.x - 1, pos.y - radius - 2, 2, 4); // simple "plus" accent
-        break;
+  public void render(SpriteBatch batch, AssetRepository assets) {
+    Texture tex = kind == Kind.CRYSTAL ? assets.getCrystal() : assets.getHuman();
+    if (tex == null) {
+      return;
     }
+    float size = radius * 2f;
+    batch.draw(tex, pos.x - radius, pos.y - radius, size, size);
   }
 
   public Kind getKind() {

--- a/core/src/main/java/com/spamalot/arcade/robostar/entity/Player.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/entity/Player.java
@@ -1,11 +1,14 @@
 package com.spamalot.arcade.robostar.entity;
 
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 
 import com.spamalot.arcade.robostar.world.WorldUtils;
+import com.spamalot.arcade.robostar.asset.AssetRepository;
+import com.spamalot.arcade.robostar.Direction;
 
 public class Player {
   private Vector2 pos = new Vector2();
@@ -86,15 +89,22 @@ public class Player {
     return shield > 0;
   }
 
-  public void render(ShapeRenderer s) {
-    // body
-    s.setColor(hasShield() ? Color.CYAN : (invuln > 0 ? Color.LIGHT_GRAY : Color.WHITE));
-    // draw a simple triangle ship
-    float r = radius;
-    s.triangle(pos.x + r, pos.y, pos.x - r, pos.y - r * 0.8f, pos.x - r, pos.y + r * 0.8f);
-    // simple thruster rectangle to suggest motion
-    s.setColor(Color.ORANGE);
-    s.rect(pos.x - r - 4, pos.y - 2, 6, 4);
+  public void render(SpriteBatch batch, AssetRepository assets) {
+    TextureRegion frame = assets.getPlayerFrame(direction(), 0);
+    if (frame == null) {
+      return;
+    }
+    float size = radius * 2f;
+    batch.setColor(hasShield() ? Color.CYAN : (invuln > 0 ? Color.LIGHT_GRAY : Color.WHITE));
+    batch.draw(frame, pos.x - radius, pos.y - radius, size, size);
+    batch.setColor(Color.WHITE);
+  }
+
+  private Direction direction() {
+    if (Math.abs(vel.x) > Math.abs(vel.y)) {
+      return vel.x >= 0 ? Direction.RIGHT : Direction.LEFT;
+    }
+    return vel.y >= 0 ? Direction.UP : Direction.DOWN;
   }
 
   public float getInvuln() {

--- a/core/src/main/java/com/spamalot/arcade/robostar/screen/PlayScreen.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/screen/PlayScreen.java
@@ -34,7 +34,7 @@ public class PlayScreen implements Screen {
     Gdx.gl.glClearColor(0, 0, 0, 1);
     Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-    world.render(game.shapes);
+    world.render(game.batch);
     hud.render(game.batch, game.shapes);
 
     if (world.lives < 0) {

--- a/core/src/main/java/com/spamalot/arcade/robostar/world/WorldManager.java
+++ b/core/src/main/java/com/spamalot/arcade/robostar/world/WorldManager.java
@@ -2,7 +2,7 @@ package com.spamalot.arcade.robostar.world;
 
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.OrthographicCamera;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
@@ -171,32 +171,32 @@ public class WorldManager {
     camera.update();
   }
 
-  public void render(ShapeRenderer shapes) {
-    shapes.setProjectionMatrix(camera.combined);
-    shapes.begin(ShapeRenderer.ShapeType.Filled);
-    player.render(shapes);
+  public void render(SpriteBatch batch) {
+    batch.setProjectionMatrix(camera.combined);
+    batch.begin();
+    player.render(batch, game.assets);
     for (Bullet b : bullets) {
-      b.render(shapes);
+      b.render(batch, game.assets.getBullet());
     }
     for (Bomb b : bombs) {
-      b.render(shapes);
+      b.render(batch, game.assets.getBomb());
     }
     for (Enemy e : enemies) {
-      e.render(shapes);
+      e.render(batch, game.assets);
     }
     for (Pickup p : crystals) {
-      p.render(shapes);
+      p.render(batch, game.assets);
     }
     for (Pickup p : humans) {
-      p.render(shapes);
+      p.render(batch, game.assets);
     }
     for (Explosion e : explosions) {
-      e.render(shapes);
+      e.render(batch, game.assets.getExplosion());
     }
     if (boss != null) {
-      boss.render(shapes);
+      boss.render(batch, game.assets.getBoss());
     }
-    shapes.end();
+    batch.end();
   }
 
   public void resize(int width, int height) {


### PR DESCRIPTION
## Summary
- Render all game entities with SpriteBatch textures rather than ShapeRenderer primitives
- Load bullet, bomb, pickup, explosion and boss textures in AssetRepository
- Pass GameRoot's SpriteBatch into WorldManager and PlayScreen

## Testing
- `mvn -q -e test` *(fails: Network is unreachable when resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68b90163a5b8833190b394aa9f7774a8